### PR TITLE
refactor lambda functions

### DIFF
--- a/rust_dynamo_get_claps/src/main.rs
+++ b/rust_dynamo_get_claps/src/main.rs
@@ -52,7 +52,7 @@ struct CustomEvent {
 #[derive(Serialize, Clone)]
 struct CustomOutput {
     #[serde(rename = "isBase64Encoded")]
-    is_base64_encoded: ::serde_json::Value,
+    is_base64_encoded: bool,
     #[serde(rename = "statusCode")]
     status_code: u16,
     body: ::serde_json::Value,
@@ -63,7 +63,7 @@ struct CustomOutput {
 impl CustomOutput {
     fn new(body: String) -> Self {
         CustomOutput {
-            is_base64_encoded: ::serde_json::Value::Bool(false),
+            is_base64_encoded: false,
             status_code: 200,
             body: ::serde_json::Value::String(body),
             headers: json!({

--- a/rust_dynamo_post_claps/src/main.rs
+++ b/rust_dynamo_post_claps/src/main.rs
@@ -153,49 +153,49 @@ async fn func(e: CustomEvent) -> Result<CustomOutput, Error> {
         ..Default::default()
     };
 
-    let mut totals_key = HashMap::new();
-    totals_key.insert(
-        "PK".to_string(),
-        AttributeValue {
-            s: Some(format!("POST#{}", body.slug)),
-            ..Default::default()
-        },
-    );
-    totals_key.insert(
-        "SK".to_string(),
-        AttributeValue {
-            s: Some(format!("#TOTAL")),
-            ..Default::default()
-        },
-    );
+    // let mut totals_key = HashMap::new();
+    // totals_key.insert(
+    //     "PK".to_string(),
+    //     AttributeValue {
+    //         s: Some(format!("POST#{}", body.slug)),
+    //         ..Default::default()
+    //     },
+    // );
+    // totals_key.insert(
+    //     "SK".to_string(),
+    //     AttributeValue {
+    //         s: Some(format!("#TOTAL")),
+    //         ..Default::default()
+    //     },
+    // );
 
-    let mut totals_expression_attribute_values = HashMap::new();
-    totals_expression_attribute_values.insert(
-        ":inc".to_string(),
-        AttributeValue {
-            n: Some(format!("{}", body.claps)),
-            ..Default::default()
-        },
-    );
-    totals_expression_attribute_values.insert(
-        ":zero".to_string(),
-        AttributeValue {
-            n: Some(format!("0")),
-            ..Default::default()
-        },
-    );
+    // let mut totals_expression_attribute_values = HashMap::new();
+    // totals_expression_attribute_values.insert(
+    //     ":inc".to_string(),
+    //     AttributeValue {
+    //         n: Some(format!("{}", body.claps)),
+    //         ..Default::default()
+    //     },
+    // );
+    // totals_expression_attribute_values.insert(
+    //     ":zero".to_string(),
+    //     AttributeValue {
+    //         n: Some(format!("0")),
+    //         ..Default::default()
+    //     },
+    // );
 
-    let update_total_input: UpdateItemInput = UpdateItemInput {
-        table_name: String::from(TABLE_NAME),
-        key: totals_key.clone(),
-        update_expression: Some("SET claps = if_not_exists(claps, :zero) + :inc".to_string()),
-        expression_attribute_values: Some(totals_expression_attribute_values),
-        // condition_expression: Some("attribute_not_exists(claps) OR (claps < :limit)".to_string()),
-        return_values: Some("UPDATED_NEW".to_string()),
-        ..Default::default()
-    };
+    // let update_total_input: UpdateItemInput = UpdateItemInput {
+    //     table_name: String::from(TABLE_NAME),
+    //     key: totals_key.clone(),
+    //     update_expression: Some("SET claps = if_not_exists(claps, :zero) + :inc".to_string()),
+    //     expression_attribute_values: Some(totals_expression_attribute_values),
+    //     // condition_expression: Some("attribute_not_exists(claps) OR (claps < :limit)".to_string()),
+    //     return_values: Some("UPDATED_NEW".to_string()),
+    //     ..Default::default()
+    // };
 
-    let mut body: ::serde_json::Value = json!({});
+    let body: ::serde_json::Value;
 
     // Update POST#<slug> #CLAPS#<ip>
     match client.update_item(update_item_input).await {
@@ -226,14 +226,14 @@ async fn func(e: CustomEvent) -> Result<CustomOutput, Error> {
     // ------------------------------
 
     // Update POST#<slug> #TOTAL
-    match client.update_item(update_total_input).await {
-        Ok(output) => {
-            println!("Successfully incremented TOTOAL {:?}", output);
-        }
-        Err(error) => {
-            println!("Failed to increment TOTAL: {:?}", error);
-        }
-    };
+    // match client.update_item(update_total_input).await {
+    //     Ok(output) => {
+    //         println!("Successfully incremented TOTOAL {:?}", output);
+    //     }
+    //     Err(error) => {
+    //         println!("Failed to increment TOTAL: {:?}", error);
+    //     }
+    // };
 
     let response = CustomOutput::new(body.to_string());
     Ok(response)


### PR DESCRIPTION
# 🦀 ⚙️ Lambda Functions

## rust_dynamo_get_claps
Use plain boolean, `false` over `is_base64_encoded: ::serde_json::Value::Bool(false)`
```diff
- is_base64_encoded: ::serde_json::Value
+ is_base64_encoded: bool
```

- [x] is deployed

## rust_dynamo_post_claps

Remove 2nd, `rusoto_dynamo` `update_item` operation that updates `POST#<slug> #TOTAL`
This `POST#<slug> #TOTAL` item is now obsolete since I learned that...

> [For Query, all items returned are treated as a single read operation.](https://stackoverflow.com/a/31628189/9823455)

...and `rust_dynamo_query_claps` has been refactored accordingly

- [x] is deployed (Can deploy this **AFTER** merging https://github.com/thiskevinwang/coffee-code-climb/pull/153)

## rust_dynamo_query_claps

Figured out how to _transform_ data, to some extent, and return a friendly JSON string format, with out Dynamo's "SS", "S", "B" weirdness
- https://github.com/thiskevinwang/rust-lambda/pull/2/files#diff-5af6e027c33800ac633fd5c9777d37c4R122-R145

- [x] is deployed (must be deployed for thiskevinwang/coffee-code-climb#153)